### PR TITLE
Unauthenticated Search

### DIFF
--- a/nginx/dockproxy
+++ b/nginx/dockproxy
@@ -41,4 +41,12 @@ server {
         
         proxy_pass http://$reg_addr:$reg_prt;
     }
+    location /v1/search {
+        proxy_buffering off;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        
+        proxy_pass http://$reg_addr:$reg_prt;
+    }
 }


### PR DESCRIPTION
The docker client doesn't provide credentials when doing 'docker search'. Adding this config block allows search to work.
